### PR TITLE
Stop killing pods before replacements start

### DIFF
--- a/src/uk/gov/defra/ffc/DefraUtils.groovy
+++ b/src/uk/gov/defra/ffc/DefraUtils.groovy
@@ -98,7 +98,7 @@ def deployChart(credentialsId, registry, imageName, tag, extraCommands) {
   withKubeConfig([credentialsId: credentialsId]) {
     def deploymentName = "$imageName-$tag"
     sh "kubectl get namespaces $deploymentName || kubectl create namespace $deploymentName"
-    sh "helm upgrade $deploymentName --install --namespace $deploymentName --recreate-pods --atomic ./helm/$imageName --set image=$registry/$imageName:$tag $extraCommands"
+    sh "helm upgrade $deploymentName --install --namespace $deploymentName --atomic ./helm/$imageName --set image=$registry/$imageName:$tag $extraCommands"
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-231

Using --redeploy-pods causes pods to be destroyed before their
replacements are ready, causing downtime. Stop using that flag and let
services control their own policies for pod redeployments.