### PR TITLE
Separate test cleanup from tests runnning

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ defraUtils.updateGithubCommitStatus('Build started', 'PENDING')
 ```
 ## Functions
 
+### replaceInFile
+
+Utility method to globally substitute text in a file. 
+
+The function takes three parameters:
+- `from`: the text to match
+- `to`: the new text to replace the matched text
+- `file`: path to file
+
+The `from` and `to` values are used directly in a sed command, so wildcards may be used.
+
+It can be tricky to correctly escape characters for sed. For example the forward slash `/` 
+needs to be escaped with a back slash, which itself need to be escaped with a back slash so the valid encoding for `/` is  `\\/`.
+
+Forward slashes in the final `file` parameter do not need escaping.
+
+Example usage to replace the path `/usr/src/app` with `./app` a path in the file `./lcov.info`:
+
+`replaceInFile('\\/usr\\/src\\/app', '.\\/app', './lcov.info')`
+
 ### getMergedPrNo
 
 Parses the local commit log to obtain the merged PR number from the message. This is reliant on the standard github merge message of the PR name followed by the PR number, i.e.

--- a/src/uk/gov/defra/ffc/DefraUtils.groovy
+++ b/src/uk/gov/defra/ffc/DefraUtils.groovy
@@ -85,9 +85,12 @@ def runTests(name, suffix) {
   } finally {
     sh "docker-compose -p $name-$suffix-$containerTag -f docker-compose.yaml -f docker-compose.test.yaml down -v"
     junit 'test-output/junit.xml'
-    // clean up files created by node/ubuntu user that cannot be deleted by jenkins. Note: uses global environment variable
-    sh "docker run --rm -u node --mount type=bind,source='$WORKSPACE/test-output',target=/usr/src/app/test-output $name rm -rf test-output/*"
   }
+}
+
+def deleteTestOutput(name) {
+    // clean up files created by node/ubuntu user that cannot be deleted by jenkins. Note: uses global environment variable
+    sh "docker run --rm -u node --mount type=bind,source='$WORKSPACE/test-output',target=/usr/src/app/test-output $name rm -rf test-output/*"  
 }
 
 def analyseCode(sonarQubeEnv, sonarScanner, params) {

--- a/src/uk/gov/defra/ffc/DefraUtils.groovy
+++ b/src/uk/gov/defra/ffc/DefraUtils.groovy
@@ -7,6 +7,10 @@ def repoUrl = ''
 def commitSha = ''
 def workspace
 
+def replaceInFile(from, to, file) {
+  sh "sed -i -e 's/$from/$to/g' $file"  
+}
+
 def getMergedPrNo() {
     def mergedPrNo = sh(returnStdout: true, script: "git log --pretty=oneline --abbrev-commit -1 | sed -n 's/.*(#\\([0-9]\\+\\)).*/\\1/p'").trim()
     return mergedPrNo ? "pr$mergedPrNo" : ''


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-420

SonarQube needs the test results to record code coverage. Currently the
test results XML file is deleted after publishing to Jenkins.

This change is to prevent tests being deleted in the runTests function.
Test output will be deleted in its own function `deleteTestOutput` that can be run in a final cleanup step.

Output paths are absolute in the LCOV report, these need to be updated for use in SonarQube. 
A utility method `replaceInFile` has been added to perform this function.