### PR TITLE
Stop specifying a service for test build

### DIFF
--- a/src/uk/gov/defra/ffc/DefraUtils.groovy
+++ b/src/uk/gov/defra/ffc/DefraUtils.groovy
@@ -121,9 +121,9 @@ def lintHelm(chartName) {
   sh "helm lint ./helm/$chartName"
 }
 
-def buildTestImage(projectName, serviceName, buildNumber) {
+def buildTestImage(projectName, buildNumber) {
   sh 'docker image prune -f || echo could not prune images'
-  sh "docker-compose -p $projectName-$containerTag-$buildNumber -f docker-compose.yaml -f docker-compose.test.yaml build --no-cache $serviceName"
+  sh "docker-compose -p $projectName-$containerTag-$buildNumber -f docker-compose.yaml -f docker-compose.test.yaml build --no-cache"
 }
 
 def runTests(projectName, serviceName, buildNumber) {


### PR DESCRIPTION
It's not necessary to specify the service(s) to build via docker-compose. By default it will build all services which have a `build` section in their configuration.