### PR TITLE
Remove redundant def's

### DIFF
--- a/src/uk/gov/defra/ffc/DefraUtils.groovy
+++ b/src/uk/gov/defra/ffc/DefraUtils.groovy
@@ -1,11 +1,4 @@
 package uk.gov.defra.ffc
-def branch = ''
-def pr = ''
-def mergedPrNo = ''
-def containerTag = ''
-def repoUrl = ''
-def commitSha = ''
-def workspace
 
 def Boolean __hasKeys(Map mapToCheck, List keys) {
     def passes = true;


### PR DESCRIPTION
Because of the way groovy works under the hood the variable definitions removed did not create globals and were redundant (see [here](https://groovy-lang.org/structure.html#_methods) for more detail, credit to @jaucourt for helping dig into this too).

This means that for, say, containerTag the assignment in [getVariables](https://github.com/DEFRA/ffc-jenkins-pipeline-library/blob/73704fe15a97b5c79636f9f3dc11a07291e798da/src/uk/gov/defra/ffc/DefraUtils.groovy#L158) is what actually creates the global var.

I would argue that we shouldn't be using global vars, and given the method returns values, this is perhaps not the intent. Before changing `getVariables` to limit variable scope I wanted to canvas opinion in case there is something I'm missing. 