### PR TITLE
Remove docker image prune command from pipelines

### DIFF
--- a/src/uk/gov/defra/ffc/DefraUtils.groovy
+++ b/src/uk/gov/defra/ffc/DefraUtils.groovy
@@ -310,7 +310,6 @@ def lintHelm(chartName) {
 
 def buildTestImage(credentialsId, registry, projectName, buildNumber) {
   docker.withRegistry("https://$registry", credentialsId) {
-    sh 'docker image prune -f || echo could not prune images'
     sh "docker-compose -p $projectName-$containerTag-$buildNumber -f docker-compose.yaml -f docker-compose.test.yaml build --no-cache"
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-553

Pruning images during pipelines can have unwanted consequences on other pipelines. Prune will be run by a nightly Jenkins job, so remove command from pipelines.